### PR TITLE
Add missing curly brackets in the first Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Given the following code and input folder structure, here is the output structur
 
 ```js
 Metalsmith(__dirname)
-	.use(i18next(
+	.use(i18next({
 		pattern: '**/*.hamlc',
 		locales: ['en','fr'],
 		namespaces: ['public']
-	))
+	}))
 	.build(function(err, files){
 		if (err) console.error(err.stack)
 	})
@@ -27,12 +27,12 @@ Metalsmith(__dirname)
 Also handlebars is supported as engine:
 
 Metalsmith(__dirname)
-	.use(i18next(
+	.use(i18next({
 		pattern: '**/*.hbs',
 		locales: ['en','fr'],
 		namespaces: ['public'],
 		engine: 'handlebars'
-	))
+	}))
 	.build(function(err, files){
 		if (err) console.error(err.stack)
 	})


### PR DESCRIPTION
## Issue
Just a small syntax error. When adding the `i18next` to Metalsmith, there were missing curly brackets around the `options` object.

## Solution
Wrapped the `options` object by curly brackets